### PR TITLE
Add basic YouTube-style interface

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,20 @@
-import { supabase } from '@/lib/supabaseClient'
+import VideoCard from '@/components/VideoCard'
+import SearchBar from '@/components/SearchBar'
+import { videos } from '@/data/videos'
 
-export default async function Home() {
-  const { data } = await supabase.from('examples').select('*').limit(1)
-
+export default function Home() {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center p-6">
-      <h1 className="text-4xl font-bold">PromptTube</h1>
-      <pre className="mt-4 text-left">{JSON.stringify(data, null, 2)}</pre>
+    <main className="p-6">
+      <div className="mb-6 flex justify-center">
+        <div className="w-full max-w-xl">
+          <SearchBar />
+        </div>
+      </div>
+      <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 md:grid-cols-3">
+        {videos.map((video) => (
+          <VideoCard key={video.id} {...video} />
+        ))}
+      </div>
     </main>
   )
 }

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+export default function SearchBar() {
+  return (
+    <input
+      type="text"
+      placeholder="Search"
+      className="w-full rounded border border-gray-300 p-2"
+    />
+  )
+}

--- a/src/components/VideoCard.tsx
+++ b/src/components/VideoCard.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+
+interface VideoCardProps {
+  title: string
+  channel: string
+  thumbnail: string
+}
+
+export default function VideoCard({ title, channel, thumbnail }: VideoCardProps) {
+  return (
+    <div className="w-64">
+      <img src={thumbnail} alt={title} className="h-36 w-full rounded object-cover" />
+      <h3 className="mt-2 font-semibold">{title}</h3>
+      <p className="text-sm text-gray-500">{channel}</p>
+    </div>
+  )
+}

--- a/src/data/videos.ts
+++ b/src/data/videos.ts
@@ -1,0 +1,27 @@
+export interface Video {
+  id: string
+  title: string
+  channel: string
+  thumbnail: string
+}
+
+export const videos: Video[] = [
+  {
+    id: 'video1',
+    title: 'Understanding React',
+    channel: 'Code Academy',
+    thumbnail: 'https://img.youtube.com/vi/dGcsHMXbSOA/hqdefault.jpg',
+  },
+  {
+    id: 'video2',
+    title: 'Next.js Tutorial',
+    channel: 'Dev Community',
+    thumbnail: 'https://img.youtube.com/vi/TTAPF6BIsw4/hqdefault.jpg',
+  },
+  {
+    id: 'video3',
+    title: 'Tailwind CSS Crash Course',
+    channel: 'DesignCode',
+    thumbnail: 'https://img.youtube.com/vi/UBOj6rqRUME/hqdefault.jpg',
+  },
+]


### PR DESCRIPTION
## Summary
- Replace home page with a simple YouTube-style layout using a search bar and grid of videos
- Add reusable `VideoCard` and `SearchBar` components
- Include sample video metadata to populate the grid

## Testing
- `npm test` *(fails: Invalid project directory provided, no such directory: /workspace/Veocraft-dari-codex/test)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689767497020832f9f8692bfc6a1ea36